### PR TITLE
Analyster-0.8.9 *** NEW JAR ***

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -7,7 +7,7 @@
     <import file="nbproject/build-impl.xml"/>
     
     <!-- set the version of Analyster here -->
-    <property name="version" value="Analyster-0.8.8"/>
+    <property name="version" value="Analyster-0.8.9"/>
     
     <!-- This creates the jar that we want with the included dependancies -->
     <!-- There should be no need to edit this code -->

--- a/src/com/elle/analyster/logic/Tab.java
+++ b/src/com/elle/analyster/logic/Tab.java
@@ -46,7 +46,7 @@ public class Tab implements ITableConstants{
     private boolean batchEditWindowOpen;
     private boolean batchEditWindowVisible;
     
-
+    
     
     /**
      * CONSTRUCTOR

--- a/src/com/elle/analyster/presentation/AnalysterWindow.java
+++ b/src/com/elle/analyster/presentation/AnalysterWindow.java
@@ -168,6 +168,10 @@ public class AnalysterWindow extends JFrame implements ITableConstants{
         jPanelEdit.setVisible(true);
         btnRevertChanges.setVisible(false);
         
+        // set upload/revert buttons initially disabled
+        btnUploadChanges.setEnabled(false);
+        btnRevertChanges.setEnabled(false);
+        
         // add filters for each table
         // must be before setting ColumnPopupMenu because this is its parameter
         tabs.get(ASSIGNMENTS_TABLE_NAME).setFilter(new TableFilter(assignmentTable));
@@ -1006,7 +1010,7 @@ public class AnalysterWindow extends JFrame implements ITableConstants{
             // set the states for this tab
             tab.setEditing(false);
             makeTableEditable(false);
-            setEnabledEditingButtons(true, true, true);
+            setEnabledEditingButtons(true, false, false);
             btnAddRecords.setEnabled(true);
             btnSwitchEditMode.setEnabled(true);
             setBatchEditButtonStates(tab);

--- a/src/com/elle/analyster/presentation/AnalysterWindow.java
+++ b/src/com/elle/analyster/presentation/AnalysterWindow.java
@@ -45,8 +45,8 @@ import java.util.Vector;
 public class AnalysterWindow extends JFrame implements ITableConstants{
     
     // Edit the version and date it was created for new archives and jars
-    private final String CREATION_DATE = "2015-09-30";  
-    private final String VERSION = "0.8.8";   
+    private final String CREATION_DATE = "2015-10-02";  
+    private final String VERSION = "0.8.9";   
     
     // attributes
     private Map<String,Tab> tabs; // stores individual tab objects 

--- a/src/com/elle/analyster/presentation/AnalysterWindow.java
+++ b/src/com/elle/analyster/presentation/AnalysterWindow.java
@@ -65,6 +65,8 @@ public class AnalysterWindow extends JFrame implements ITableConstants{
     // colors - Edit mode labels
     private Color editModeDefaultTextColor;
     private Color editModeActiveTextColor;
+    
+    private String editingTabName; // stores the name of the tab that is editing
 
 
     /**
@@ -1139,6 +1141,11 @@ public class AnalysterWindow extends JFrame implements ITableConstants{
             else{
                 setEnabledEditingButtons(false, true, true);
             }
+            
+            // set edit mode label
+            labelEditMode.setText("Edit Mode: ");
+            labelEditModeState.setVisible(true);
+            editModeTextColor(true);
         }
         
         // else if no tab is editing
@@ -1146,6 +1153,12 @@ public class AnalysterWindow extends JFrame implements ITableConstants{
             btnSwitchEditMode.setEnabled(true);
             btnAddRecords.setEnabled(true);
             btnBatchEdit.setEnabled(true);
+            
+            // set edit mode label
+            labelEditMode.setText("Edit Mode: ");
+            labelEditModeState.setVisible(true);
+            
+            editModeTextColor(false);
         }
         
         // else if there is a tab editing but it is not this one
@@ -1153,6 +1166,11 @@ public class AnalysterWindow extends JFrame implements ITableConstants{
             btnSwitchEditMode.setEnabled(false);
             btnAddRecords.setEnabled(false);
             btnBatchEdit.setEnabled(false);
+            
+            // set edit mode label
+            labelEditMode.setText("Editing " + getEditingTabName() + " ... ");
+            labelEditModeState.setVisible(false);
+            editModeTextColor(true);
         }
     }
 
@@ -2382,6 +2400,7 @@ public class AnalysterWindow extends JFrame implements ITableConstants{
             
             // if editing break and return true
             if(isEditing){
+                editingTabName = entry.getKey();
                 break;
             }
         }
@@ -2456,6 +2475,12 @@ public class AnalysterWindow extends JFrame implements ITableConstants{
         ((Window)(c)).setAlwaysOnTop(true);
         
     }
+
+    public String getEditingTabName() {
+        return editingTabName;
+    }
+    
+    
     
     // @formatter:off
     // Variables declaration - do not modify//GEN-BEGIN:variables

--- a/src/com/elle/analyster/presentation/AnalysterWindow.java
+++ b/src/com/elle/analyster/presentation/AnalysterWindow.java
@@ -1211,14 +1211,24 @@ public class AnalysterWindow extends JFrame implements ITableConstants{
      * @param evt 
      */
     private void btnAddRecordsActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnAddRecordsActionPerformed
-        addRecordsWindow = new AddRecordsWindow();
-        addRecordsWindow.setVisible(true);
         
+        // if no add records window is open
+        if(addRecordsWindow == null || !addRecordsWindow.isDisplayable()){
+            addRecordsWindow = new AddRecordsWindow();
+            addRecordsWindow.setVisible(true);
+        }
+        
+        // if window is already open then set the focus
+        else {
+            addRecordsWindow.toFront();
+        }
+
         // update records
         String tabName = getSelectedTabName();
         Tab tab = tabs.get(tabName);
         String recordsLabel = tab.getRecordsLabel();
         labelRecords.setText(recordsLabel);
+        
     }//GEN-LAST:event_btnAddRecordsActionPerformed
 
     /**
@@ -2478,6 +2488,10 @@ public class AnalysterWindow extends JFrame implements ITableConstants{
 
     public String getEditingTabName() {
         return editingTabName;
+    }
+
+    public AddRecordsWindow getAddRecordsWindow() {
+        return addRecordsWindow;
     }
     
     

--- a/src/com/elle/analyster/presentation/AnalysterWindow.java
+++ b/src/com/elle/analyster/presentation/AnalysterWindow.java
@@ -1177,6 +1177,9 @@ public class AnalysterWindow extends JFrame implements ITableConstants{
         tab.setBatchEditBtnEnabled(false);
         setBatchEditButtonStates(tab);
         
+        // show the batch edit window in front of the Main Window
+        showWindowInFront(batchEditWindow);
+        
     }//GEN-LAST:event_btnBatchEditActionPerformed
 
     private void menuItemManageDBsActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_menuItemManageDBsActionPerformed
@@ -2441,6 +2444,17 @@ public class AnalysterWindow extends JFrame implements ITableConstants{
             labelEditMode.setForeground(editModeDefaultTextColor);
             labelEditModeState.setForeground(editModeDefaultTextColor);
         }
+    }
+    
+    /**
+     * showWindowInFront
+     * This shows the component in front of the Main Window
+     * @param c Any component that needs to show on top of the Main window
+     */
+    public void showWindowInFront(Component c){
+
+        ((Window)(c)).setAlwaysOnTop(true);
+        
     }
     
     // @formatter:off


### PR DESCRIPTION
Analyster-0.8.9 *** NEW JAR ***
 - Batch edit button does not change the upload/revert options 
 - batch edit window now shows always on top of the main window
 - edit Mode text for other tabs that are not editing ( editing tabNameHere ... )
   - this also displays in green when editing is active
 - addrecords button creates a new window if not opened and sets focus to top is a window is already open